### PR TITLE
forward.hpp: Dual explicit conversion

### DIFF
--- a/autodiff/forward/forward.hpp
+++ b/autodiff/forward/forward.hpp
@@ -458,6 +458,8 @@ struct Dual
 
     Dual() : Dual(0.0) {}
 
+    operator T() const { return this->val; }
+    
     template<typename U, enableif<isNumber<U>>...>
     Dual(U&& other) : val(other), grad(0) {}
 


### PR DESCRIPTION
Fix for issue https://github.com/autodiff/autodiff/issues/26

Added explicit conversion from Dual<T,G> to T allowing Eigen casts to work out of the box. e.g:
VectorXdual x;
VectorXd y;
y = x.cast<double>();